### PR TITLE
feat: add custom cli types for string maps

### DIFF
--- a/types/stringmap.go
+++ b/types/stringmap.go
@@ -1,0 +1,74 @@
+package types
+
+import "encoding/json"
+
+type DeepStringMapFlag struct {
+	parts map[string]map[string]string
+}
+
+func (d *DeepStringMapFlag) String() string {
+	return ""
+}
+
+func (d *DeepStringMapFlag) Get() map[string]map[string]string {
+	return d.parts
+}
+
+func (d *DeepStringMapFlag) Set(value string) error {
+	d.parts = map[string]map[string]string{}
+
+	err := json.Unmarshal([]byte(value), &d.parts)
+	if err != nil {
+		single := map[string]string{}
+
+		err := json.Unmarshal([]byte(value), &single)
+		if err != nil {
+			return err
+		}
+
+		d.parts["*"] = single
+	}
+
+	return nil
+}
+
+type StringMapFlag struct {
+	parts map[string]string
+}
+
+func (s *StringMapFlag) String() string {
+	return ""
+}
+
+func (s *StringMapFlag) Get() map[string]string {
+	return s.parts
+}
+
+func (s *StringMapFlag) Set(value string) error {
+	s.parts = map[string]string{}
+
+	err := json.Unmarshal([]byte(value), &s.parts)
+	if err != nil {
+		s.parts["*"] = value
+	}
+
+	return nil
+}
+
+type MapFlag struct {
+	parts map[string]string
+}
+
+func (m *MapFlag) String() string {
+	return ""
+}
+
+func (m *MapFlag) Get() map[string]string {
+	return m.parts
+}
+
+func (m *MapFlag) Set(value string) error {
+	m.parts = map[string]string{}
+
+	return json.Unmarshal([]byte(value), &m.parts)
+}

--- a/types/stringslice.go
+++ b/types/stringslice.go
@@ -1,8 +1,6 @@
-package plugin
+package types
 
-import (
-	"strings"
-)
+import "strings"
 
 // StringSliceFlag is a flag type which support comma separated values and escaping to not split at unwanted lines.
 type StringSliceFlag struct {

--- a/types/stringslice_test.go
+++ b/types/stringslice_test.go
@@ -1,4 +1,4 @@
-package plugin
+package types
 
 import (
 	"reflect"


### PR DESCRIPTION
BREAKING CHANGE: The existing type `StringSliceFlag` was moved to the new `types` package. 