### PR TITLE
feat: coerce non-string JSON values in StringMap flags

### DIFF
--- a/cli/flag_deep_string_map.go
+++ b/cli/flag_deep_string_map.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/urfave/cli/v3"
 )
+
+var errParseDeepStringMap = errors.New("unable to parse flag value as JSON string map")
 
 // DeepStringMapFlag is a flag type which supports nested JSON string maps.
 type (
@@ -53,30 +57,39 @@ func (d DeepStringMap) ToString(v map[string]map[string]string) string {
 }
 
 // Set implements the flag.Value interface.
+// Valid nested JSON objects are parsed directly. JSON values that are not
+// strings (numbers, booleans, null) are coerced to their string
+// representations. Flat (non-nested) JSON objects are stored under the "*"
+// key with the same coercion applied. Input that is not valid JSON returns
+// an error.
 func (d *DeepStringMap) Set(v string) error {
+	*d.destination = map[string]map[string]string{}
+
 	if v == "" {
-		*d.destination = map[string]map[string]string{}
+		return nil
+	}
+
+	if err := json.Unmarshal([]byte(v), d.destination); err == nil {
+		return nil
+	}
+
+	var rawNested map[string]map[string]any
+	if json.Unmarshal([]byte(v), &rawNested) == nil {
+		*d.destination = convertNestedMap(rawNested)
 
 		return nil
 	}
 
-	err := json.Unmarshal([]byte(v), d.destination)
-	if err != nil {
-		// Try to parse as a single-level map
-		single := map[string]string{}
-
-		err := json.Unmarshal([]byte(v), &single)
-		if err != nil {
-			return err
+	var rawSingle map[string]any
+	if json.Unmarshal([]byte(v), &rawSingle) == nil {
+		*d.destination = map[string]map[string]string{
+			"*": convertFlatMap(rawSingle),
 		}
 
-		// Store the single-level map under a wildcard key
-		(*d.destination) = map[string]map[string]string{
-			"*": single,
-		}
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("%w: %q", errParseDeepStringMap, v)
 }
 
 // Get implements the flag.Value interface.

--- a/cli/flag_deep_string_map_test.go
+++ b/cli/flag_deep_string_map_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestDeepStringMapSet(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  map[string]map[string]string
+		name    string
+		input   string
+		want    map[string]map[string]string
+		wantErr bool
 	}{
 		{
 			name:  "empty string",
@@ -38,6 +39,102 @@ func TestDeepStringMapSet(t *testing.T) {
 			input: "{}",
 			want:  map[string]map[string]string{},
 		},
+		{
+			name:  "nested with boolean value",
+			input: `{"group1":{"enabled":true}}`,
+			want:  map[string]map[string]string{"group1": {"enabled": "true"}},
+		},
+		{
+			name:  "nested with numeric values",
+			input: `{"group1":{"count":42,"ratio":3.14}}`,
+			want:  map[string]map[string]string{"group1": {"count": "42", "ratio": "3.14"}},
+		},
+		{
+			name:  "nested with null value",
+			input: `{"group1":{"empty":null}}`,
+			want:  map[string]map[string]string{"group1": {"empty": ""}},
+		},
+		{
+			name:  "nested with mixed value types",
+			input: `{"group1":{"str":"hello","flag":false,"num":7,"empty":null}}`,
+			want:  map[string]map[string]string{"group1": {"str": "hello", "flag": "false", "num": "7", "empty": ""}},
+		},
+		{
+			name:  "flat map with boolean value",
+			input: `{"enabled":true}`,
+			want:  map[string]map[string]string{"*": {"enabled": "true"}},
+		},
+		{
+			name:  "flat map with numeric values",
+			input: `{"count":42,"ratio":3.14}`,
+			want:  map[string]map[string]string{"*": {"count": "42", "ratio": "3.14"}},
+		},
+		{
+			name:  "nested with null-only group",
+			input: `{"group1":null}`,
+			want:  map[string]map[string]string{"group1": nil},
+		},
+		{
+			name:  "flat map with mixed value types",
+			input: `{"str":"hello","flag":false,"num":7,"empty":null}`,
+			want:  map[string]map[string]string{"*": {"str": "hello", "flag": "false", "num": "7", "empty": ""}},
+		},
+		{
+			name:    "not parseable input returns error",
+			input:   `not-json`,
+			want:    map[string]map[string]string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]map[string]string
+
+			d := &DeepStringMap{
+				destination: &got,
+			}
+
+			err := d.Set(tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDeepStringMapSetRoundtrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "valid nested JSON",
+			input: `{"group1":{"key1":"value1","key2":"value2"}}`,
+			want:  `{"group1":{"key1":"value1","key2":"value2"}}`,
+		},
+		{
+			name:  "nested with non-string values",
+			input: `{"group1":{"enabled":true,"count":42}}`,
+			want:  `{"group1":{"count":"42","enabled":"true"}}`,
+		},
+		{
+			name:  "flat map fallback",
+			input: `{"key1":"value1","key2":"value2"}`,
+			want:  `{"*":{"key1":"value1","key2":"value2"}}`,
+		},
+		{
+			name:  "flat map with non-string values",
+			input: `{"flag":false,"num":7,"empty":null}`,
+			want:  `{"*":{"empty":"","flag":"false","num":"7"}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -50,7 +147,14 @@ func TestDeepStringMapSet(t *testing.T) {
 
 			err := d.Set(tt.input)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+
+			result := d.String()
+
+			var expected, actual map[string]map[string]string
+
+			_ = json.Unmarshal([]byte(tt.want), &expected)
+			_ = json.Unmarshal([]byte(result), &actual)
+			assert.EqualValues(t, expected, actual)
 		})
 	}
 }

--- a/cli/flag_string_map.go
+++ b/cli/flag_string_map.go
@@ -49,6 +49,11 @@ func (s StringMap) ToString(v map[string]string) string {
 }
 
 // Set implements the flag.Value interface.
+// JSON values that are not strings (numbers, booleans, null) are coerced to
+// their string representations. Input that is not valid JSON at all is stored
+// as-is under the "*" key. Set intentionally never returns errors.
+//
+//nolint:nilerr
 func (s *StringMap) Set(v string) error {
 	*s.destination = map[string]string{}
 
@@ -56,9 +61,19 @@ func (s *StringMap) Set(v string) error {
 		return nil
 	}
 
-	err := json.Unmarshal([]byte(v), s.destination)
-	if err != nil {
+	if err := json.Unmarshal([]byte(v), s.destination); err == nil {
+		return nil
+	}
+
+	var raw map[string]any
+	if json.Unmarshal([]byte(v), &raw) != nil {
 		(*s.destination)["*"] = v
+
+		return nil
+	}
+
+	for k, val := range raw {
+		(*s.destination)[k] = coerceToString(val)
 	}
 
 	return nil

--- a/cli/flag_string_map_test.go
+++ b/cli/flag_string_map_test.go
@@ -38,6 +38,76 @@ func TestStringMapSet(t *testing.T) {
 			input: "{}",
 			want:  map[string]string{},
 		},
+		{
+			name:  "boolean value",
+			input: `{"enabled":true}`,
+			want:  map[string]string{"enabled": "true"},
+		},
+		{
+			name:  "numeric values",
+			input: `{"count":42,"ratio":3.14}`,
+			want:  map[string]string{"count": "42", "ratio": "3.14"},
+		},
+		{
+			name:  "null value",
+			input: `{"empty":null}`,
+			want:  map[string]string{"empty": ""},
+		},
+		{
+			name:  "null with non-string values",
+			input: `{"count":42,"empty":null}`,
+			want:  map[string]string{"count": "42", "empty": ""},
+		},
+		{
+			name:  "mixed string, bool, and numeric",
+			input: `{"str":"hello","flag":false,"num":7}`,
+			want:  map[string]string{"str": "hello", "flag": "false", "num": "7"},
+		},
+		{
+			name:  "top-level JSON array",
+			input: `["foo","bar"]`,
+			want:  map[string]string{"*": `["foo","bar"]`},
+		},
+		{
+			name:  "top-level JSON string primitive",
+			input: `"just a string"`,
+			want:  map[string]string{"*": `"just a string"`},
+		},
+		{
+			name:  "top-level JSON number primitive",
+			input: `42`,
+			want:  map[string]string{"*": "42"},
+		},
+		{
+			name:  "top-level JSON boolean primitive",
+			input: `true`,
+			want:  map[string]string{"*": "true"},
+		},
+		{
+			name:  "top-level JSON null primitive",
+			input: `null`,
+			want:  nil,
+		},
+		{
+			name:  "nested object value",
+			input: `{"a":{"b":1}}`,
+			want:  map[string]string{"a": `{"b":1}`},
+		},
+		{
+			name:  "nested array value",
+			input: `{"a":[1,2,3]}`,
+			want:  map[string]string{"a": "[1,2,3]"},
+		},
+		{
+			name:  "float edge case",
+			input: `{"val":0.30000000000000004}`,
+			want:  map[string]string{"val": "0.30000000000000004"},
+		},
+		{
+			name:  "malformed JSON that looks like a map",
+			input: `{"foo": bar}`,
+			want:  map[string]string{"*": `{"foo": bar}`},
+		},
 	}
 
 	for _, tt := range tests {
@@ -51,6 +121,61 @@ func TestStringMapSet(t *testing.T) {
 			err := s.Set(tt.input)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, dest)
+		})
+	}
+}
+
+func TestStringMapSetRoundtrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "boolean value",
+			input: `{"enabled":true}`,
+			want:  `{"enabled":"true"}`,
+		},
+		{
+			name:  "numeric values",
+			input: `{"count":42,"ratio":3.14}`,
+			want:  `{"count":"42","ratio":"3.14"}`,
+		},
+		{
+			name:  "null value",
+			input: `{"empty":null}`,
+			want:  `{"empty":""}`,
+		},
+		{
+			name:  "mixed types",
+			input: `{"str":"hello","flag":false,"num":7}`,
+			want:  `{"flag":"false","num":"7","str":"hello"}`,
+		},
+		{
+			name:  "non-JSON fallback",
+			input: `not-json`,
+			want:  `{"*":"not-json"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dest map[string]string
+
+			s := &StringMap{
+				destination: &dest,
+			}
+
+			err := s.Set(tt.input)
+			assert.NoError(t, err)
+
+			got := s.String()
+
+			var expected, actual map[string]string
+
+			_ = json.Unmarshal([]byte(tt.want), &expected)
+			_ = json.Unmarshal([]byte(got), &actual)
+			assert.EqualValues(t, expected, actual)
 		})
 	}
 }

--- a/cli/string_map_helper.go
+++ b/cli/string_map_helper.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// coerceToString converts any JSON value to a string representation.
+func coerceToString(val any) string {
+	if val == nil {
+		return ""
+	}
+
+	switch t := val.(type) {
+	case map[string]any, []any:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Sprint(t)
+		}
+
+		return string(b)
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+// convertNestedMap converts map[string]map[string]any to map[string]map[string]string.
+func convertNestedMap(rawNested map[string]map[string]any) map[string]map[string]string {
+	result := make(map[string]map[string]string, len(rawNested))
+
+	for group, rawGroup := range rawNested {
+		result[group] = make(map[string]string, len(rawGroup))
+
+		for k, val := range rawGroup {
+			result[group][k] = coerceToString(val)
+		}
+	}
+
+	return result
+}
+
+// convertFlatMap converts map[string]any to map[string]string.
+func convertFlatMap(raw map[string]any) map[string]string {
+	result := make(map[string]string, len(raw))
+
+	for k, val := range raw {
+		result[k] = coerceToString(val)
+	}
+
+	return result
+}


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/wp-plugin-go/issues/241

Enhance `StringMap` and `DeepStringMap` to accept JSON with non-string
values (numbers, booleans, null) by coercing them to strings. Add
helper functions for type conversion and comprehensive test coverage.

`DeepStringMap` now returns a wrapped error for invalid JSON input and
always clears the destination on parse failure.